### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,9 +267,9 @@ function trustMulti(subnets) {
         }
 
         // Convert IP to match subnet IP kind
-        ipconv = ipconv || subnetkind === 'ipv4'
+        ipconv = ipconv || (subnetkind === 'ipv4'
           ? ip.toIPv4Address()
-          : ip.toIPv4MappedAddress();
+          : ip.toIPv4MappedAddress());
         trusted = ipconv;
       }
 


### PR DESCRIPTION
The update of dependency "ipaddr.js": "1.1.0" cause "TypeError: ip.toIPv4Address is not a function" since class ipaddr.IPv4 doesn't have function toIPv4Address anymore