### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "jshttp/proxy-addr",
   "dependencies": {
     "forwarded": "~0.1.2",
-    "ipaddr.js": "1.5.2"
+    "ipaddr.js": "1.5.3"
   },
   "devDependencies": {
     "benchmark": "2.1.4",


### PR DESCRIPTION
ipaddr.js's 1.5.2 release had a bug when attempting to require it. 1.5.3 fixed it.