### PR TITLE
fix: allow CIDR prefix length /0 to trust all addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,7 @@ function parseipNotation (note) {
     range = null
   }
 
-  if (range <= 0 || range > max) {
+  if (range === null || range < 0 || range > max) {
     throw new TypeError('invalid range on address: ' + note)
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -235,6 +235,13 @@ describe('proxyaddr(req, trust)', function () {
       assert.strictEqual(proxyaddr(req, '10.0.0.2/26'), '10.0.0.200')
     })
 
+    it('should accept /0 CIDR to trust all addresses', function () {
+      var req = createReq('10.0.0.1', {
+        'x-forwarded-for': '192.168.0.1, 172.16.0.1'
+      })
+      assert.strictEqual(proxyaddr(req, '0.0.0.0/0'), '192.168.0.1')
+    })
+
     it('should accept netmask notation', function () {
       var req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.200'
@@ -488,6 +495,14 @@ describe('proxyaddr.compile(trust)', function () {
         assert.throws(proxyaddr.compile.bind(null, '::1/6000'), /invalid range on address/)
         assert.throws(proxyaddr.compile.bind(null, '::ffff:a00:2/136'), /invalid range on address/)
         assert.throws(proxyaddr.compile.bind(null, '::ffff:a00:2/-46'), /invalid range on address/)
+      })
+
+      it('should accept IPv4 CIDR /0', function () {
+        assert.strictEqual(typeof proxyaddr.compile('0.0.0.0/0'), 'function')
+      })
+
+      it('should accept IPv6 CIDR /0', function () {
+        assert.strictEqual(typeof proxyaddr.compile('::/0'), 'function')
       })
 
       it('should not alter input array', function () {


### PR DESCRIPTION
## Summary

Fixes the range validation in `parseipNotation` to accept `/0` as a valid CIDR prefix length.

## Problem

`0.0.0.0/0` and `::/0` are valid CIDR notation meaning "match all addresses", but `proxyaddr.compile('0.0.0.0/0')` throws `TypeError: invalid range on address: 0.0.0.0/0`.

This is because the validation check on line 191 used `range <= 0`, which incorrectly treated `0` as invalid:

```js
if (range <= 0 || range > max) {
  throw new TypeError('invalid range on address: ' + note)
}
```

This affects users who want to trust all proxy addresses (e.g., when behind a reverse proxy that already handles trust). The issue was reported with Mastodon's streaming server which sets `app.set('trust proxy', '0.0.0.0/0')`.

## Fix

Changed the validation to explicitly check for `null` (which represents an unparseable format) separately from the numeric bound check:

```js
if (range === null || range < 0 || range > max) {
  throw new TypeError('invalid range on address: ' + note)
}
```

This allows `0` as a valid prefix length while still rejecting:
- Negative ranges (e.g., `-46`)
- Ranges exceeding the max (e.g., `/6000`, `/136` for IPv6)
- Unparseable formats (where `range` is `null`)

## Testing

Added 3 new tests:
- `proxyaddr.compile('0.0.0.0/0')` accepts IPv4 CIDR /0
- `proxyaddr.compile('::/0')` accepts IPv6 CIDR /0
- `proxyaddr(req, '0.0.0.0/0')` functionally trusts all IPv4 addresses

All 73 tests pass. Lint clean.

Fixes #28