### PR TITLE
Fix "arugment" typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ proxyaddr(req, function (addr) { return addr === '127.0.0.1' })
 proxyaddr(req, function (addr, i) { return i < 1 })
 ```
 
-The `trust` arugment may also be a single IP address string or an
+The `trust` argument may also be a single IP address string or an
 array of trusted addresses, as plain IP addresses, CIDR-formatted
 strings, or IP/netmask strings.
 


### PR DESCRIPTION
Hi,

thanks for the package. While going through the readme I noticed "argument" was spelled wrong in one occasion.

BR,
Marten